### PR TITLE
ctypes add stubs link flags

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -242,8 +242,8 @@ jobs:
         uses: actions/checkout@v3
       - uses: whoan/docker-build-with-cache-action@v6
         with:
-          image_name: monorepo-benchmark
-          build_extra_args: '{"--file": "bench/monorepo/bench.Dockerfile"}'
+          image_name: monorepobenchmark
+          dockerfile: bench/monorepo/bench.Dockerfile
           push_image_and_stages: true
-          username: ocaml
+          username: ocamldune
           password: "${{ secrets.DOCKER_HUB_PASSWORD }}"

--- a/doc/changes/copy-sandbox-dirs.md
+++ b/doc/changes/copy-sandbox-dirs.md
@@ -1,0 +1,1 @@
+- Make copy sandbox support directory targets. (#8705, fixes #7724, @emillon)

--- a/src/dune_rules/ctypes/ctypes_rules.ml
+++ b/src/dune_rules/ctypes/ctypes_rules.ml
@@ -482,8 +482,7 @@ let gen_rules ~cctx ~(buildable : Buildable.t) ~loc ~scope ~dir ~sctx =
           ~c_types_includer_module))
 ;;
 
-let ctypes_cclib_flags sctx ~expander ~(buildable : Buildable.t) =
-  let standard = Action_builder.return [] in
+let ctypes_cclib_flags ?(standard = Action_builder.return []) sctx ~expander ~(buildable : Buildable.t)  =
   match buildable.ctypes with
   | None -> standard
   | Some ctypes ->

--- a/src/dune_rules/ctypes/ctypes_rules.mli
+++ b/src/dune_rules/ctypes/ctypes_rules.mli
@@ -10,7 +10,8 @@ val gen_rules
   -> unit Memo.t
 
 val ctypes_cclib_flags
-  :  Super_context.t
+  : ?standard:(string list Action_builder.t)
+  ->  Super_context.t
   -> expander:Expander.t
   -> buildable:Dune_file.Buildable.t
   -> string list Action_builder.t

--- a/src/dune_rules/lib_rules.ml
+++ b/src/dune_rules/lib_rules.ml
@@ -329,9 +329,7 @@ let build_stubs lib ~cctx ~dir ~expander ~requires ~dir_contents ~vlib_stubs_o_f
         Cxx_flags.get_flags ~for_:Link (Context.build_context ctx)
       | _ -> Action_builder.return []
     in
-    let c_library_flags =
-      Expander.expand_and_eval_set expander lib.c_library_flags ~standard
-    in
+    let c_library_flags = Ctypes_rules.ctypes_cclib_flags sctx ~expander ~buildable:lib.buildable ~standard in
     let lib_o_files_for_all_modes = Mode.Map.Multi.for_all_modes o_files in
     let for_all_modes = List.rev_append vlib_stubs_o_files lib_o_files_for_all_modes in
     if Mode.Dict.Set.to_list modes.ocaml

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune
@@ -1,0 +1,4 @@
+(executable
+ (name example)
+ (modes byte)
+ (libraries examplelib))

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune-project
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.10)
+
+(using ctypes 0.3)

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune-workspace
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/dune-workspace
@@ -1,0 +1,6 @@
+(lang dune 3.10)
+
+; (context
+;  (default
+;   (disable_dynamically_linked_foreign_archives true)))
+;

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/example.ml
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/example.ml
@@ -1,0 +1,2 @@
+let () =
+  Printf.printf "%d\n" (Examplelib.C.Functions.add2 2)

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/run.t
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/run.t
@@ -1,0 +1,105 @@
+
+Build an example library as a DLL and set up the environment so that it looks
+like a system/distro library that can be probed with pkg-config and dynamically
+loaded.
+
+DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX"  PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix"  dune exec ./example.bc --display=short
+Reference output
+
+
+The program is run as bytecode wihout linking in either the stub stub dll or
+external dll.
+
+
+Run the program in bytecode
+
+  $ LIBEX=$(realpath "$PWD/../libexample")
+  $ tree $LIBEX
+  /workspace_root/test/blackbox-tests/test-cases/ctypes/libexample
+  |-- example.h -> ../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/example.h
+  |-- libexample.a -> ../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/libexample.a
+  |-- libexample.so -> ../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/libexample.so
+  `-- pkgconfig
+      `-- libexample.pc -> ../../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/pkgconfig/libexample.pc
+  
+  1 directory, 4 files
+  $ DYLD_LIBRARY_PATH="$LIBEX" LD_LIBRARY_PATH="$LIBEX"  PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix" dune build stubgen/dllexamplelib_stubs.so
+  + cc -shared -undefined dynamic_lookup -Wl,-w   -g -o stubgen/dllexamplelib_stubs.so stubgen/libexample__c_cout_generated_functions__Function_description__Functions.o  -L/workspace_root/test/blackbox-tests/test-cases/ctypes/libexample -lexample   
+  + ar rcs stubgen/libexamplelib_stubs.a  stubgen/libexample__c_cout_generated_functions__Function_description__Functions.o
+
+  $ CAML_LD_LIBRARY_PATH="$LIBEX/_build/default/stubgen" DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$LIBEX" LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$LIBEX"  PKG_CONFIG_PATH="$LIBEX/pkgconfig" PKG_CONFIG_ARGN="--define-prefix"  dune build --display=short ./example.bc
+      ocamldep stubgen/.examplelib.objs/examplelib__C.impl.d
+    pkg-config stubgen/.pkg-config/libexample.cflags
+    pkg-config stubgen/.pkg-config/libexample.libs
+  libexample__function_gen__Function_description__Functions stubgen/libexample__c_generated_functions__Function_description__Functions.ml
+      ocamldep stubgen/.examplelib.objs/examplelib__Libexample__c_generated_functions__Function_description__Functions.impl.d
+        ocamlc stubgen/.examplelib.objs/byte/examplelib__Libexample__c_generated_functions__Function_description__Functions.{cmi,cmo,cmt}
+        ocamlc stubgen/.examplelib.objs/byte/examplelib__C.{cmi,cmo,cmt}
+        ocamlc .example.eobjs/byte/dune__exe__Example.{cmi,cmti}
+        ocamlc stubgen/examplelib.cma
+        ocamlc .example.eobjs/byte/dune__exe__Example.{cmo,cmt}
+        ocamlc example.bc
+
+  $ tree $LIBEX
+  /workspace_root/test/blackbox-tests/test-cases/ctypes/libexample
+  |-- example.h -> ../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/example.h
+  |-- libexample.a -> ../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/libexample.a
+  |-- libexample.so -> ../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/libexample.so
+  `-- pkgconfig
+      `-- libexample.pc -> ../../../../../../../../../default/test/blackbox-tests/test-cases/ctypes/libexample/pkgconfig/libexample.pc
+  
+  1 directory, 4 files
+ 
+
+Explictly set LIBRARY_PATH at runtime,otherwise dlopen cannot find libexample. (TODO, fix with rpath and clean after install?)
+
+  $ DYLD_LIBRARY_PATH="$DYLD_LIBRARY_PATH:$LIBEX" CAML_LD_LIBRARY_PATH="$CAML_LD_LIBRARY_PATH:$PWD/_build/default/stubgen" ocamlrun _build/default/example.bc --display=short2>&1|sed  's/.sandbox\/[^/]*/SANDBOX_ID/g'
+  4
+
+Verify libexample is referenced in stubs.
+
+TODO: example of manual/relative paths  
+osx:
+install_name_tool -id libexample.so @rpath/libexample.so
+#Then some other tool sets @rpath.
+- Use @rpath when building/linking
+- 
+
+
+  $ install_name_tool -change libexample.so ../libexample/libexample.so _build/default/stubgen/dllexamplelib_stubs.so
+  $ ls _build/default/stubgen/../../../../libexample
+  example.h
+  libexample.a
+  libexample.so
+  pkgconfig
+  $ otool -l _build/default/stubgen/dllexamplelib_stubs.so |grep -A3 RPATH
+  [1]
+  $ otool -L _build/default/stubgen/dllexamplelib_stubs.so
+  _build/default/stubgen/dllexamplelib_stubs.so:
+  	stubgen/dllexamplelib_stubs.so (compatibility version 0.0.0, current version 0.0.0)
+  	../libexample/libexample.so (compatibility version 0.0.0, current version 0.0.0)
+  	/usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
+
+  $ ls ../libexample
+  example.h
+  libexample.a
+  libexample.so
+  pkgconfig
+  $ echo "STRING $TESTCASE_ROOT"|  sed 's/a//'
+  STRING 
+  $ echo "$LIBEX"
+  /workspace_root/test/blackbox-tests/test-cases/ctypes/libexample
+
+  $ echo $PWD
+  $TESTCASE_ROOT
+  $ ocamlrun -I _build/default/stubgen _build/default/example.bc --display=short2>&1|sed
+  4
+
+
+Trace of pkg-config flags
+
+  $ cat _build/default/stubgen/.pkg-config/libexample.cflags
+  -I/workspace_root/test/blackbox-tests/test-cases/ctypes/libexample
+  $ cat _build/default/stubgen/.pkg-config/libexample.libs
+  -L/workspace_root/test/blackbox-tests/test-cases/ctypes/libexample -lexample
+

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/dune
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/dune
@@ -1,0 +1,14 @@
+(library
+  (name examplelib)
+  (flags (:standard -w -9-27))
+  (ctypes
+    (external_library_name libexample)
+    (build_flags_resolver pkg_config)
+    (headers (include "example.h"))
+    (type_description
+      (instance Types)
+      (functor Type_description))
+    (function_description
+      (instance Functions)
+      (functor Function_description))
+    (generated_entry_point C)))

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/function_description.ml
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/function_description.ml
@@ -1,0 +1,8 @@
+open Ctypes
+
+module Types = Types_generated
+
+module Functions (F : Ctypes.FOREIGN) = struct
+  open F
+  let add2 = foreign "example_add2" (int @-> returning int)
+end

--- a/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/type_description.ml
+++ b/test/blackbox-tests/test-cases/ctypes/bytecode-stubs-external-lib.t/stubgen/type_description.ml
@@ -1,0 +1,3 @@
+module Types (F : Ctypes.TYPE) = struct
+
+end

--- a/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
+++ b/test/blackbox-tests/test-cases/directory-targets/copy-sandboxing.t
@@ -14,10 +14,11 @@ mode:
   >  (target foo)
   >  (deps (sandbox always) output/)
   >  (action
-  >   (run touch foo)))
+  >   (progn
+  >    (bash "ls output | sort")
+  >    (run touch foo))))
   > EOF
 
   $ dune build foo --sandbox=copy
-  Error: Is a directory
-  -> required by _build/default/foo
-  [1]
+  x
+  y

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env-no-build.t
@@ -1,0 +1,30 @@
+In this test we test the translation of a package with a build-env field and no build or
+install step into a dune lock file.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+Make a package with a build-env field and no build or install step
+  $ mkpkg with-build-env <<'EOF'
+  > opam-version: "2.0"
+  > build-env: [ [ MY_ENV_VAR = "Hello from env var!" ] ]
+  > EOF
+
+  $ mkdir -p $mock_packages/with-build-env/with-build-env.0.0.1/
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends with-build-env))
+  > EOF
+  Solution for dune.lock:
+  with-build-env.0.0.1
+  
+
+When there is no build or install step the build environment does not appear in the lock
+file.
+
+  $ cat dune.lock/with-build-env.pkg 
+  (version 0.0.1)

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-env.t
@@ -30,18 +30,17 @@ The lockfile should contain a setenv action.
   (version 0.0.1)
   
   (install
-   (run sh -c "echo $MY_ENV_VAR"))
+   (withenv
+    ((= MY_ENV_VAR "Hello from env var!"))
+    (run sh -c "echo $MY_ENV_VAR")))
   
   (build
-   (run sh -c "echo $MY_ENV_VAR"))
+   (withenv
+    ((= MY_ENV_VAR "Hello from env var!"))
+    (run sh -c "echo $MY_ENV_VAR")))
 
-  $ mkdir source
-  $ cat > source/foo.ml <<EOF
-  > This is wrong
-  > EOF
-
-printenv should print the value given in the build-env field.
+This should print the value given in the build-env field.
 
   $ MY_ENV_VAR="invisible" build_pkg with-build-env 
-  invisible
-  invisible
+  Hello from env var!
+  Hello from env var!

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-build-test-and-build-doc.t
@@ -1,0 +1,37 @@
+Older opam files contain the deprecated `build-test` and `build-doc` fields which has
+since been deprecated to the `build` field with a filter.
+
+In this test we demonstrate that we don't currently do anything special with those fields.
+
+  $ . ./helpers.sh
+  $ mkrepo
+
+  $ mkpkg with-build-test-doc <<EOF
+  > opam-version: "2.0"
+  > build: [ "echo" "Building" ]
+  > build-doc: [ "echo" "Building doc" ]
+  > build-test: [ "echo" "Building test" ]
+  > EOF
+
+  $ mkdir -p $mock_packages/with-build-test-doc/with-build-test-doc.0.0.1
+
+  $ solve_project <<EOF
+  > (lang dune 3.8)
+  > (package
+  >  (name x)
+  >  (allow_empty)
+  >  (depends with-build-test-doc))
+  > EOF
+  Solution for dune.lock:
+  with-build-test-doc.0.0.1
+  
+The lockfile should contain the `build-test` and `build-doc` fields inside the build
+action.
+
+This is currently not the case. 
+
+  $ cat dune.lock/with-build-test-doc.pkg 
+  (version 0.0.1)
+  
+  (build
+   (run echo Building))

--- a/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
+++ b/test/blackbox-tests/test-cases/pkg/opam-package-with-setenv.t
@@ -3,19 +3,30 @@ Testing the translation of the setenv field of an opam file into the dune lock d
   $ . ./helpers.sh
   $ mkrepo
 
-Make a package with a setenv 
+Make a package with a setenv. We also test all the kinds of env updates here expcept for
+=+= which isn't used at all in the wild. 
   $ mkpkg with-setenv <<EOF
   > opam-version: "2.0"
   > setenv: [
   >  [EXPORTED_ENV_VAR = "Hello from the other package!"]
+  >  [prepend_with_trailing_sep := "Prepended with trailing sep"]
+  >  [prepend_without_trailing_sep += "Prepended without trailing sep"]
+  >  [append_without_leading_sep =+ "Appended without leading sep"]
+  >  [append_with_leading_sep =: "Appended with leading sep"]
   > ]
   > EOF
 
-Make another package that depends on that and outputs the exported env var
+Make another package that depends on that and outputs the exported env vars
   $ mkpkg deps-on-with-setenv <<'EOF'
   > opam-version: "2.0"
   > depends: [ "with-setenv" ]
-  > build: [ "sh" "-c" "echo $EXPORTED_ENV_VAR" ]
+  > build: [
+  >  [ "sh" "-c" "echo $EXPORTED_ENV_VAR" ]
+  >  [ "sh" "-c" "echo $prepend_without_trailing_sep" ]
+  >  [ "sh" "-c" "echo $prepend_with_trailing_sep" ]
+  >  [ "sh" "-c" "echo $append_without_leading_sep" ]
+  >  [ "sh" "-c" "echo $append_with_leading_sep" ]
+  > ]
   > EOF
 
   $ mkdir -p $mock_packages/with-setenv/with-setenv.0.0.1
@@ -40,12 +51,26 @@ The exported env from the first package should be in the lock dir.
   (version 0.0.1)
   
   (build
-   (run sh -c "echo $EXPORTED_ENV_VAR"))
+   (progn
+    (run sh -c "echo $EXPORTED_ENV_VAR")
+    (run sh -c "echo $prepend_without_trailing_sep")
+    (run sh -c "echo $prepend_with_trailing_sep")
+    (run sh -c "echo $append_without_leading_sep")
+    (run sh -c "echo $append_with_leading_sep")))
   
   (deps with-setenv)
 
-When building the second package the exported env var from the first package should be
-available.
+When building the second package the exported env vars from the first package should be
+available and all the env updates should be applied correctly.
 
-  $ EXPORTED_ENV_VAR="I have not been exported yet." build_pkg deps-on-with-setenv 
+  $ EXPORTED_ENV_VAR="I have not been exported yet." \
+  > prepend_without_trailing_sep="foo:bar" \
+  > prepend_with_trailing_sep="foo:bar" \
+  > append_without_leading_sep="foo:bar" \
+  > append_with_leading_sep="foo:bar" \
+  > build_pkg deps-on-with-setenv 
   I have not been exported yet.
+  foo:bar
+  foo:bar
+  foo:bar
+  foo:bar


### PR DESCRIPTION
- fix(bench): set correct account names for docker (#8628)
- Add directory target support to copy sandbox (#8705)
- test(pkg): test env updates in opam-package-with-setenv (#8702)
- test(pkg): translation of build-doc and build-test of opam to lockfile (#8687)
- feature(pkg): translate build-env from opam file into lock dir (#8701)
- Add link flags to ocamlmklib.
